### PR TITLE
Display NFA or DFA as svg File

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,12 @@ More information about the graphviz attributes [here](https://www.graphviz.org/d
 # Default styling
 automata.view("DFA Visualization")
 
+# You an decide between png and svg file formats
 # If you want to add custom styling, you can use the following
 
 automata.view(
     file_name="DFA Custom Styling",
+    file_format="png" or "svg",
     node_attr={'fontsize': '20'},
     edge_attr={'fontsize': '20pt'}
 )
@@ -200,10 +202,12 @@ not_automata.accept("000001")    #True
 # Default styling
 automata.view("NFA Visualization")
 
+# You an decide between png and svg file formats
 # If you want to add custom styling, you can use the following
 
 automata.view(
     file_name="NFA Custom Styling",
+    file_format="png" or "svg",
     node_attr={'fontsize': '20'},
     edge_attr={'fontsize': '20pt'}
 )

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ More information about the graphviz attributes [here](https://www.graphviz.org/d
 # Default styling
 automata.view("DFA Visualization")
 
-# You an decide between png and svg file formats
+# You can decide between png and svg file formats
 # If you want to add custom styling, you can use the following
 
 automata.view(
@@ -202,7 +202,7 @@ not_automata.accept("000001")    #True
 # Default styling
 automata.view("NFA Visualization")
 
-# You an decide between png and svg file formats
+# You can decide between png and svg file formats
 # If you want to add custom styling, you can use the following
 
 automata.view(

--- a/automathon/finite_automata/dfa.py
+++ b/automathon/finite_automata/dfa.py
@@ -20,6 +20,9 @@ from graphviz import (
 from typing import (
     Callable,
 )
+from typing import (
+    Literal
+)
 import itertools
 
 
@@ -385,12 +388,13 @@ class DFA:
     def view(
         self,
         file_name: str,
+        file_format: Literal["svg", "png"] = "png",
         node_attr: dict[str, str] | None = None,
         edge_attr: dict[str, str] | None = None,
     ) -> None:
         dot = Digraph(
             name=file_name,
-            format="png",
+            format=file_format,
             node_attr=node_attr,
             edge_attr=edge_attr,
         )

--- a/automathon/finite_automata/nfa.py
+++ b/automathon/finite_automata/nfa.py
@@ -23,6 +23,10 @@ from graphviz import (
     Digraph,
 )
 
+from typing import (
+    Literal
+)
+
 
 @dataclass
 class NFA:
@@ -679,12 +683,13 @@ class NFA:
     def view(
         self,
         file_name: str,
+        file_format: Literal["svg", "png"] = "png",
         node_attr: dict[str, str] | None = None,
         edge_attr: dict[str, str] | None = None,
     ) -> None:
         dot = Digraph(
             name=file_name,
-            format="png",
+            format=file_format,
             node_attr=node_attr,
             edge_attr=edge_attr,
         )

--- a/docs/dfa.md
+++ b/docs/dfa.md
@@ -92,7 +92,7 @@ automata.view("DFA Visualization")
 # Add custom styling or change the file format
 
 automata.view(file_name="DFA Custom Styling",
-              file_format="png or svg",
+              file_format="png" or "svg",
               node_attr={'fontsize': '20'},
               edge_attr={'fontsize': '20pt'})
 ```

--- a/docs/dfa.md
+++ b/docs/dfa.md
@@ -89,9 +89,10 @@ Example:
 ```python
 automata.view("DFA Visualization")
 
-# Add custom styling
+# Add custom styling or change the file format
 
 automata.view(file_name="DFA Custom Styling",
+              file_format="png or svg",
               node_attr={'fontsize': '20'},
               edge_attr={'fontsize': '20pt'})
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -201,10 +201,12 @@ not_automata.accept("000001")    #True
 # Default styling
 automata.view("NFA Visualization")
 
+# You an decide between png and svg file formats
 # If you want to add custom styling, you can use the following
 
 automata.view(
     file_name="NFA Custom Styling",
+    file_format="png" or "svg",
     node_attr={'fontsize': '20'},
     edge_attr={'fontsize': '20pt'}
 )

--- a/docs/index.md
+++ b/docs/index.md
@@ -201,7 +201,7 @@ not_automata.accept("000001")    #True
 # Default styling
 automata.view("NFA Visualization")
 
-# You an decide between png and svg file formats
+# You can decide between png and svg file formats
 # If you want to add custom styling, you can use the following
 
 automata.view(

--- a/docs/nfa.md
+++ b/docs/nfa.md
@@ -111,10 +111,11 @@ automata.
 ```python
 automata.view("NFA Visualization")
 
-# Add custom styling
+# Add custom styling or change the file format
 
 automata.view(
     file_name="NFA Custom Styling",
+    file_format="png" or "svg",
     node_attr={'fontsize': '20'},
     edge_attr={'fontsize': '20pt'}
 )


### PR DESCRIPTION
Add a parameter to the DFA.view() function to decide which file format to write to.
**Allowed file types**
- png (default)
- sng